### PR TITLE
Improve note creation flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
   <div id="note-panel">
     <textarea id="note-input" placeholder="Введите заметку..."></textarea>
     <button id="save-btn">💾 Сохранить заметку</button>
+    <p id="message"></p>
     <ul id="note-list"></ul>
   </div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,8 @@ const notes = JSON.parse(localStorage.getItem('notes')) || [];
 const list = document.getElementById('note-list');
 const input = document.getElementById('note-input');
 const button = document.getElementById('save-btn');
+const message = document.getElementById('message');
+let pendingText = null;
 
 function renderNotes() {
   list.innerHTML = '';
@@ -27,16 +29,31 @@ function addMarkerAndNote(text, latlng) {
   renderNotes();
 }
 
+function updateButtonState() {
+  button.disabled = input.value.trim() === '' || pendingText !== null;
+}
+
+input.addEventListener('input', updateButtonState);
+
 map.on('click', e => {
-  const text = input.value.trim();
-  if (!text) return;
-  addMarkerAndNote(text, e.latlng);
-  input.value = '';
+  if (pendingText) {
+    addMarkerAndNote(pendingText, e.latlng);
+    pendingText = null;
+    message.textContent = '';
+    updateButtonState();
+  }
 });
 
 button.addEventListener('click', () => {
-  alert('Чтобы сохранить заметку, кликните по карте!');
+  const text = input.value.trim();
+  if (!text) return;
+  pendingText = text;
+  input.value = '';
+  message.textContent = 'Теперь выберите место на карте';
+  updateButtonState();
 });
+
+updateButtonState();
 
 renderNotes();
 notes.forEach(note => L.marker(note.latlng).addTo(map).bindPopup(note.text));

--- a/style.css
+++ b/style.css
@@ -56,3 +56,8 @@ h1 {
   background: #e0e0e0;
   border-radius: 4px;
 }
+
+#message {
+  margin-top: 0.5em;
+  color: #317EFB;
+}


### PR DESCRIPTION
## Summary
- capture note text on Save button and wait for map click
- disable save button until text is entered
- show inline instructions instead of alert

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685300d17fdc8320810f94ea27d56a42